### PR TITLE
Fix Arch Linux compiling issue

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -17,7 +17,7 @@
 			<compilerflag value="-I/usr/include/at-spi-2.0" />
 
 			<compilerflag value="-I/usr/include/dbus-1.0" />
-			<compilerflag value="-I/usr/lib/x86_64-linux-gnu/dbus-1.0/include" />
+			<compilerflag value="-I/usr/lib/dbus-1.0/include" />
 
 			<compilerflag value="-I/usr/include/gio-unix-2.0" />
 			<compilerflag value="-I/usr/include/pango-1.0" />
@@ -34,7 +34,7 @@
 			<compilerflag value="-I/usr/include/blkid" />
 
 			<compilerflag value="-I/usr/include/glib-2.0" />
-			<compilerflag value="-I/usr/lib/x86_64-linux-gnu/glib-2.0/include" />
+			<compilerflag value="-I/usr/lib/glib-2.0/include" />
 		</section>
 
 		<compilerflag value="-I${haxelib:hxnativefiledialog}/project/nativefiledialog/src/include" />


### PR DESCRIPTION
Changed dbus and glib include paths to use /usr/lib/dbus-1.0/include and /usr/lib/glib-2.0/include instead of architecture-specific directories. This improves compatibility across different system configurations.